### PR TITLE
Drop support to EOL ruby versions:

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,15 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -38,4 +35,3 @@ jobs:
       run: bundle exec rake
     - name: Ruby Lint
       run: bundle exec rubocop
-      

--- a/github_diff_parser.gemspec
+++ b/github_diff_parser.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage = "https://github.com/Edouard-chin/git_diff_parser"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
Drop support to EOL ruby versions:

- Drop support for Ruby 2.6 and 2.7