### PR TITLE
Extract more info from the hunk header:

### DIFF
--- a/lib/github_diff_parser/diff.rb
+++ b/lib/github_diff_parser/diff.rb
@@ -47,8 +47,8 @@ module GithubDiffParser
     #
     # @example Representation of the previous_lino_start and new_lino_start in a Git Diff
     #   @@ -6,5 +6,6 @@ def test1 # => The first 6 is the previous_lino_start, the second is the new_lino_start
-    def add_hunk(previous_lino_start, new_lino_start)
-      hunks << Hunk.new(previous_lino_start, new_lino_start)
+    def add_hunk(previous_lino_start, new_lino_start, context)
+      hunks << Hunk.new(previous_lino_start, new_lino_start, context)
     end
 
     # Add a line belonging to the previously processed Git Hunk.

--- a/lib/github_diff_parser/hunk.rb
+++ b/lib/github_diff_parser/hunk.rb
@@ -11,14 +11,19 @@ module GithubDiffParser
     # @return [Integer] (see #initialize)
     attr_reader :new_file_start_line
 
+    # @return [String] (see #initialize)
+    attr_reader :context
+
     # @param previous_file_start_line [String] the starting line number of the hunk for the original file
     # @param new_file_start_line [String] the starting line number of the hunk for the new file
+    # @param context [String]
     #
     # @example Representation of the previous_file_start_line and new_file_start_line in a Git Diff
     #   @@ -6,5 +6,6 @@ def test1 # => The first 6 is the previous_file_start_line the second is the new_file_start_line
-    def initialize(previous_file_start_line, new_file_start_line)
+    def initialize(previous_file_start_line, new_file_start_line, context)
       @previous_file_start_line = Integer(previous_file_start_line)
       @new_file_start_line = Integer(new_file_start_line)
+      @context = context
       @lines = []
     end
 
@@ -81,6 +86,24 @@ module GithubDiffParser
     # @return [GithubDiffParser::Line, nil]
     def find_current_line(line_number)
       lines.find { |line| line.current_number == line_number }
+    end
+
+    # The number of lines in the previous version.
+    #
+    # @example
+    #   "@@ +3,4 -3,8 @@" This would return "4"
+    #   "@@ +3 -3 @@"     This would return "1"
+    def previous_line_count
+      contextual_lines.count + deletion_lines.count
+    end
+
+    # The number of lines in the new version.
+    #
+    # @example
+    #   "@@ +3,4 -3,8 @@" This would return "8"
+    #   "@@ +3 -3 @@"     This would return "1"
+    def new_line_count
+      contextual_lines.count + addition_lines.count
     end
   end
 end

--- a/lib/github_diff_parser/parser.rb
+++ b/lib/github_diff_parser/parser.rb
@@ -81,7 +81,7 @@ module GithubDiffParser
     def add_hunk_to_diff(match_data)
       validate_diff
 
-      @current_diff.add_hunk(match_data[:previous_lino_start], match_data[:new_lino_start])
+      @current_diff.add_hunk(match_data[:previous_lino_start], match_data[:new_lino_start], match_data[:context])
     end
 
     # Called when encountering a `-text` or `+text` or ` text` in the Git Diff output.

--- a/lib/github_diff_parser/regexes.rb
+++ b/lib/github_diff_parser/regexes.rb
@@ -115,7 +115,7 @@ module GithubDiffParser
       @@\s                                             # Match '@@ '
       -(?<previous_lino_start>\d+)(,\d+)?\s            # Match '-1,11 ' or match '-1 ' and capture the '1' part
       \+(?<new_lino_start>\d+)(,\d+)?\s                # Match '+1,34 ' or match '+1 ' and capture the '1' part
-      @@.*                                             # Match '@@ Any text'
+      @@\s?(?<context>.*)                              # Match '@@ Any text' and capture the 'Any text' part
       \Z                                               # End of line
     }x
 

--- a/test/github_diff_parser_test.rb
+++ b/test/github_diff_parser_test.rb
@@ -16,6 +16,9 @@ class GithubDiffParserTest < Minitest::Test
     assert_equal(6, hunk.lines.count)
     assert_equal(5, hunk.contextual_lines.count)
     assert_equal(1, hunk.addition_lines.count)
+    assert_equal("def test1", hunk.context)
+    assert_equal(5, hunk.previous_line_count)
+    assert_equal(6, hunk.new_line_count)
 
     expected_lines = [
       {
@@ -81,6 +84,9 @@ class GithubDiffParserTest < Minitest::Test
     assert_equal(6, hunk.lines.count)
     assert_equal(5, hunk.contextual_lines.count)
     assert_equal(1, hunk.deletion_lines.count)
+    assert_equal("def test1", hunk.context)
+    assert_equal(6, hunk.previous_line_count)
+    assert_equal(5, hunk.new_line_count)
 
     expected_lines = [
       {
@@ -147,6 +153,9 @@ class GithubDiffParserTest < Minitest::Test
     assert_equal(5, hunk.contextual_lines.count)
     assert_equal(1, hunk.deletion_lines.count)
     assert_equal(1, hunk.addition_lines.count)
+    assert_equal("def test1", hunk.context)
+    assert_equal(6, hunk.previous_line_count)
+    assert_equal(6, hunk.new_line_count)
 
     expected_lines = [
       {
@@ -219,6 +228,9 @@ class GithubDiffParserTest < Minitest::Test
     hunk = parsed_diff.hunks.first
     assert_equal(10, hunk.lines.count)
     assert_equal(10, hunk.addition_lines.count)
+    assert_equal("", hunk.context)
+    assert_equal(0, hunk.previous_line_count)
+    assert_equal(10, hunk.new_line_count)
 
     expected_lines = [
       {
@@ -312,6 +324,9 @@ class GithubDiffParserTest < Minitest::Test
     hunk = parsed_diff.hunks.first
     assert_equal(11, hunk.lines.count)
     assert_equal(11, hunk.deletion_lines.count)
+    assert_equal("", hunk.context)
+    assert_equal(11, hunk.previous_line_count)
+    assert_equal(0, hunk.new_line_count)
 
     expected_lines = [
       {
@@ -428,6 +443,9 @@ class GithubDiffParserTest < Minitest::Test
     assert_equal(7, hunk.lines.count)
     assert_equal(6, hunk.contextual_lines.count)
     assert_equal(1, hunk.deletion_lines.count)
+    assert_equal("class Railtie < Rails::Railtie # :nodoc:", hunk.context)
+    assert_equal(7, hunk.previous_line_count)
+    assert_equal(6, hunk.new_line_count)
 
     expected_lines = [
       {
@@ -484,6 +502,9 @@ class GithubDiffParserTest < Minitest::Test
     assert_equal(6, hunk.contextual_lines.count)
     assert_equal(3, hunk.deletion_lines.count)
     assert_equal(9, hunk.addition_lines.count)
+    assert_equal("class Railtie < Rails::Railtie # :nodoc:", hunk.context)
+    assert_equal(9, hunk.previous_line_count)
+    assert_equal(15, hunk.new_line_count)
 
     expected_lines = [
       {


### PR DESCRIPTION
- Added the `Hunk#context`, `Hunk#previous_line_count` and `Hunk#new_line_count` methods.

  In this example header `@@ +1,6 -1,18 def blabla`, the methods would respectively return:

  1) "def blabla"
  2) 6
  3) 18

  The `*line_count` methods are computed rather than extracted because those number are optional in a git diff output depending on how many lines were changed.