### PR TITLE
Fix the `previous_line_number_is_now` method returning a wrong value:

### DIFF
--- a/lib/github_diff_parser/diff.rb
+++ b/lib/github_diff_parser/diff.rb
@@ -140,7 +140,7 @@ module GithubDiffParser
     #
     # @return [Integer]
     def previous_line_number_is_now(line_number)
-      return line_number unless line_shifted?(line_number)
+      return line_number if line_unchanged?(line_number)
 
       applicable_hunk = last_applicable_hunk_for_line(line_number)
       line = applicable_hunk.find_previous_line(line_number)
@@ -196,16 +196,13 @@ module GithubDiffParser
 
     private
 
-    # Check if a line was shifted. A line is considered shifted if its number is superior to the first hunk's start
-    # range.
-    #
     # @param line_number [Integer]
     #
     # @return [Boolean]
-    def line_shifted?(line_number)
+    def line_unchanged?(line_number)
       first_hunk = hunks.first
 
-      line_number > first_hunk.new_file_start_line
+      line_number < first_hunk.new_file_start_line
     end
 
     # Find the last hunk that shifts the line. We need the last because we know it's the one that will shift the line

--- a/test/data/first_line_shifted.diff
+++ b/test/data/first_line_shifted.diff
@@ -1,0 +1,10 @@
+diff --git a/my_file.rb b/my_file.rb
+index 479ddd7700..80acf01257 100644
+--- a/my_file.rb
++++ b/my_file.rb
+@@ -1,2 +1,4 @@
++# typed: false
++# frozen_string_literal: true
+ # Blablabla
+ # Example
+ # Something something

--- a/test/previous_line_number_is_now_test.rb
+++ b/test/previous_line_number_is_now_test.rb
@@ -55,4 +55,12 @@ class PreviousLineNumberIsNowTest < Minitest::Test
 
     assert_equal(68, current_number)
   end
+
+  def test_when_first_line_is_shifted
+    parsed_diffs = GithubDiffParser.parse(read_diff("first_line_shifted"))
+
+    current_number = parsed_diffs.first.previous_line_number_is_now(1)
+
+    assert_equal(3, current_number)
+  end
 end


### PR DESCRIPTION
- The `previous_line_number_is_now` could return a wrong value for the line number one in a file.